### PR TITLE
 🔌 Add folder aliasing through react-app-rewire-alias

### DIFF
--- a/frontend/config-overrides.js
+++ b/frontend/config-overrides.js
@@ -1,0 +1,12 @@
+const { alias } = require('react-app-rewire-alias');
+
+module.exports = function override(config) {
+  alias({
+    '@assets': 'src/assets',
+    '@components': 'src/components',
+    '@pages': 'src/pages',
+    '@styles': 'src/styles'
+  })(config);
+
+  return config;
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12273,6 +12273,29 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
+    "react-app-rewire-alias": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-app-rewire-alias/-/react-app-rewire-alias-1.0.0.tgz",
+      "integrity": "sha512-BhtjZMDEB21iuvH+2YhCW3NTRt1PcoCsEe7SXbwIejf/YDqXqDfAl7tR/9Emtvu1Ubz0pqW2qXKrUDS7VDw+Zw==",
+      "dev": true
+    },
+    "react-app-rewired": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-2.1.8.tgz",
+      "integrity": "sha512-wjXPdKPLscA7mn0I1de1NHrbfWdXz4S1ladaGgHVKdn1hTgKK5N6EdGIJM0KrS6bKnJBj7WuqJroDTsPKKr66Q==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "react-dev-utils": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.2.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,9 +15,9 @@
     "web-vitals": "^1.1.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -37,5 +37,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "react-app-rewire-alias": "^1.0.0",
+    "react-app-rewired": "^2.1.8"
   }
 }


### PR DESCRIPTION
I added folder aliasing for easier imports by installing the `react-app-rewire-alias`. The `config-overrides.js` file contains the details of which folders are aliased and can be changed if more folders are added. Please keep in mind that this also changes the script commands in `package.json` for the front end. Closes #59.