### PR TITLE
⌛ Update make meeting query to input start and end date and times

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,13 +23,26 @@ app.use(express.static(path.join(__dirname, 'frontend/build')));
 
 // Create meeting and send back meetCode
 app.post("/api/makeMeeting", (req, res) => {
+  const defaultDate = '2021-02-20 00:00:00-00';
+  const defaultTime = ' 00:00:00-00';
   const meetingID = utils.generateID();
-  const { meetingName } = req.body;
-  const password = utils.generatePassword(); 
+  let { meetingName,
+          startDate,
+          endDate,
+          startTime,
+          endTime } = req.body;
+  
+  // come back to make a more elegant solution
+  startDate = startDate === '' ? defaultDate : startDate + defaultTime;
+  endDate = endDate === '' ? defaultDate : endDate + defaultTime;
+  startTime = startTime === '' ? defaultTime : startTime;
+  endTime = endTime === '' ? defaultTime : endDate;
+  const password = utils.generatePassword();
 
   const query =
-    'insert into meetings (meetingID, meetingName, password) values ($1, $2, $3);';
-  client.query(query, [meetingID, meetingName, password], (err, res) => {
+    `insert into meetings (meetingID, meetingName, password, starttimestamp, endtimestamp, earliesttime, latesttime
+      ) values ($1, $2, $3, $4, $5, $6, $7);`;
+  client.query(query, [meetingID, meetingName, password, startDate, endDate, startTime, endTime], (err, res) => {
     if (err) throw err;
   });
   console.log('Posted new meeting to db.');


### PR DESCRIPTION
# Changes
- Unpacked all date time values in the backend
- Change query to insert them with the meeting
- Accomodate for null values

**Note:** We don't have to accomodate for things other than null values because our frontend restricts the user to only null values or correctly formatted date time values.